### PR TITLE
Update Pillar doc link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ http://guillep.github.io/ecstatic/
 Pillar is a document model for [Pharo](http://www.pharo.org) that can be exported to different formats such as HTML or LaTex. Pillar defines also a syntax to describe documents and provides a parser for it. To know a bit more about how to write pillar documents you may find useful the two following links.
 
 - [Pillar Cheat Sheet](http://www.cheatography.com/benjaminvanryseghem/cheat-sheets/pillar/)
-- [Pillar docs](http://files.pharo.org/books/enterprise-pharo/book/PillarChap/Pillar.html)
+- [Pillar docs](https://ci.inria.fr/pharo-contribution/job/EnterprisePharoBook/lastSuccessfulBuild/artifact/book-result/PillarChap/Pillar.html)
 
 
 ### TODOs


### PR DESCRIPTION
Pillar documentation link was broken, changed it to: https://ci.inria.fr/pharo-contribution/job/EnterprisePharoBook/lastSuccessfulBuild/artifact/book-result/PillarChap/Pillar.html
