### PR TITLE
Adding .bat file in _scripts

### DIFF
--- a/_scripts/ecstatic.bat
+++ b/_scripts/ecstatic.bat
@@ -1,0 +1,1 @@
+%~dp0\Pharo.exe --headless %~dp0\Pharo.image ecstatic %* %CD%


### PR DESCRIPTION
As suggested in issue #11 , the .bat script is added next to the other scripts.